### PR TITLE
Fix notices after config entity conversion

### DIFF
--- a/ldap_authentication/LdapAuthenticationConfAdmin.class.php
+++ b/ldap_authentication/LdapAuthenticationConfAdmin.class.php
@@ -265,7 +265,7 @@ class LdapAuthenticationConfAdmin extends LdapAuthenticationConf {
     if ($servers = ldap_servers_get_servers(NULL, 'enabled')) {
       foreach ($servers as $sid => $ldap_server) {
         $enabled = ($ldap_server->get('status')) ? 'Enabled' : 'Disabled';
-        $this->authenticationServersOptions[$sid] = $ldap_server->name . ' (' . $ldap_server->address . ') Status: ' . $enabled;
+        $this->authenticationServersOptions[$sid] = $ldap_server->get('label') . ' (' . $ldap_server->get('address') . ') Status: ' . $enabled;
       }
     }
   }

--- a/ldap_user/ldap_user.module
+++ b/ldap_user/ldap_user.module
@@ -315,7 +315,7 @@ function ldap_user_ldap_attributes_needed_alter(&$attributes, $params) {
  */
 function ldap_user_ldap_user_attrs_list_alter(&$available_user_attrs, &$params) {
 
-  $sid = (isset($params['ldap_server']) && is_object($params['ldap_server'])) ? $params['ldap_server']->sid : LDAP_USER_NO_SERVER_SID;
+  $sid = (isset($params['ldap_server']) && is_object($params['ldap_server'])) ? $params['ldap_server']->get('id') : LDAP_USER_NO_SERVER_SID;
 
   $ldap_user_conf = $params['ldap_user_conf'];
   $direction = isset($params['direction']) ? $params['direction'] : LDAP_USER_PROV_DIRECTION_NONE;


### PR DESCRIPTION
``$ldap_server`` is a config entity. We have to use the ``get`` method.