### PR TITLE
Remove ldap_server_php_supports_pagination

### DIFF
--- a/ldap_servers/ldap_servers.module
+++ b/ldap_servers/ldap_servers.module
@@ -852,11 +852,6 @@ function ldap_servers_decrypt($encrypted, $encryption = NULL) {
   return _ldap_servers_decrypt($encrypted, $encryption);
 }
 
-function ldap_servers_php_supports_pagination() {
-  return (boolean)(function_exists('ldap_control_paged_result_response') && function_exists('ldap_control_paged_result'));
-}
-
-
 function ldap_servers_help($path, $arg) {
 
   $servers_help = '<p>' . t('LDAP Servers store "LDAP server configurations" so other modules can connect to them and leverage their data.') . ' ';

--- a/ldap_servers/src/Entity/Server.php
+++ b/ldap_servers/src/Entity/Server.php
@@ -40,6 +40,7 @@ use Drupal\ldap_servers\ServerInterface;
  * )
  */
 class Server extends ConfigEntityBase implements ServerInterface {
+
   /**
    * The Server ID.
    *
@@ -486,12 +487,12 @@ class Server extends ConfigEntityBase implements ServerInterface {
       'scope = ' . $scope,
       )
     );
-    if ($this->detailed_watchdog_log) {
+    if (\Drupal::config('ldap_help.settings')->get('watchdog_detail')) {
       \Drupal::logger('ldap_server')->notice($query, array());
     }
 
     // When checking multiple servers, there's a chance we might not be connected yet.
-    if (! $this->connection) {
+    if (!$this->connection) {
       $this->connect();
       $this->bind();
     }
@@ -509,7 +510,7 @@ class Server extends ConfigEntityBase implements ServerInterface {
       'scope' => $scope,
     );
 
-    if ($this->searchPagination && $this->paginationEnabled) {
+    if ($this->get('search_pagination')) {
       $aggregated_entries = $this->pagedLdapQuery($ldap_query_params);
       return $aggregated_entries;
     }
@@ -557,12 +558,9 @@ class Server extends ConfigEntityBase implements ServerInterface {
    *
    */
   public function pagedLdapQuery($ldap_query_params) {
-
-    if (!($this->searchPagination && $this->paginationEnabled)) {
-       \Drupal::logger('ldap')->notice("LDAP server pagedLdapQuery() called when functionality not available in php install or
-        not enabled in ldap server configuration.  error. basedn: %basedn| filter: %filter| attributes:
-         %attributes| errmsg: %errmsg| ldap err no: %errno|", []);
-      RETURN FALSE;
+    if (!$this->get('search_pagination')) {
+      \Drupal::logger('ldap')->notice("LDAP server pagedLdapQuery() called when functionality not enabled in ldap server configuration.  error. basedn: %basedn| filter: %filter| attributes: %attributes| errmsg: %errmsg| ldap err no: %errno|", []);
+      return FALSE;
     }
 
     $paged_entries = array();

--- a/ldap_servers/src/Form/ServerForm.php
+++ b/ldap_servers/src/Form/ServerForm.php
@@ -452,14 +452,12 @@ class ServerForm extends EntityForm {
       '#default_value' => $server->get('search_pagination'),
       '#type' => 'checkbox',
       '#title' => t('Use LDAP Pagination.'),
-      '#disabled' => !ldap_servers_php_supports_pagination(),
     );
 
     $form['pagination']['search_page_size'] = array(
       '#default_value' => $server->get('search_page_size'),
       '#type' => 'textfield',
       '#size' => 10,
-      '#disabled' => !ldap_servers_php_supports_pagination(),
       '#title' => t('Pagination size limit.'),
       '#description' => t('This should be equal to or smaller than the max
         number of entries returned at a time by your ldap server.


### PR DESCRIPTION
I think its safe to remove ldap_servers_php_supports_pagination because D8 requires a newer PHP Version and these functions are always available.