### PR TITLE
fix function calls to non-existing function update_variables_to_config()

### DIFF
--- a/ldap_help/ldap_help.install
+++ b/ldap_help/ldap_help.install
@@ -23,9 +23,11 @@ function ldap_help_uninstall() {
  * @ingroup config_upgrade
  */
 function ldap_help_update_8000() {
-  update_variables_to_config('ldap_help.settings', array(
-    'ldap_help_watchdog_detail' => 'watchdog_detail',
-    'ldap_help_user_data_clear' => 'user_data_clear',
-    'ldap_help_user_data_clear_set_date' => 'user_data_clear_set_date',
-  ));
+  if (function_exists('update_variables_to_config')) {
+    update_variables_to_config('ldap_help.settings', array(
+      'ldap_help_watchdog_detail' => 'watchdog_detail',
+      'ldap_help_user_data_clear' => 'user_data_clear',
+      'ldap_help_user_data_clear_set_date' => 'user_data_clear_set_date',
+    ));
+  }
 }

--- a/ldap_servers/ldap_servers.install
+++ b/ldap_servers/ldap_servers.install
@@ -65,8 +65,10 @@ function ldap_servers_requirements($phase) {
 * @ingroup config_upgrade
 */
 function ldap_servers_update_8000() {
-  update_variables_to_config('ldap_servers.settings', array(
-    'ldap_servers_encryption' => 'encryption',
-    'ldap_servers_require_ssl_for_credentials' => 'require_ssl_for_credentials',
-  ));
+  if (function_exists('update_variables_to_config')) {
+    update_variables_to_config('ldap_servers.settings', array(
+      'ldap_servers_encryption' => 'encryption',
+      'ldap_servers_require_ssl_for_credentials' => 'require_ssl_for_credentials',
+    ));
+  }
 }

--- a/ldap_user/ldap_user.install
+++ b/ldap_user/ldap_user.install
@@ -121,7 +121,9 @@ function ldap_user_schema() {
  * @ingroup config_upgrade
  */
 function ldap_user_update_8001() {
-  update_variables_to_config('ldap_user.settings', array(
-    'ldap_user_cron_last_uid_checked' => 'cron_last_uid_checked',
-  ));
+  if (function_exists('update_variables_to_config')) {
+    update_variables_to_config('ldap_user.settings', array(
+      'ldap_user_cron_last_uid_checked' => 'cron_last_uid_checked',
+    ));
+  }
 }


### PR DESCRIPTION
Function update_variables_to_config() does not exist in Drupal 8.0.x. It was removed in this commit https://github.com/drupal/drupal/commit/bc058bada9f5deda6301e4bf85d21236ed267ad9 from Drupal core.