### PR TITLE
fix invalid update with hook_update_8000()

### DIFF
--- a/ldap_help/ldap_help.install
+++ b/ldap_help/ldap_help.install
@@ -22,7 +22,7 @@ function ldap_help_uninstall() {
  *
  * @ingroup config_upgrade
  */
-function ldap_help_update_8000() {
+function ldap_help_update_8001() {
   if (function_exists('update_variables_to_config')) {
     update_variables_to_config('ldap_help.settings', array(
       'ldap_help_watchdog_detail' => 'watchdog_detail',

--- a/ldap_servers/ldap_servers.install
+++ b/ldap_servers/ldap_servers.install
@@ -64,7 +64,7 @@ function ldap_servers_requirements($phase) {
 *
 * @ingroup config_upgrade
 */
-function ldap_servers_update_8000() {
+function ldap_servers_update_8001() {
   if (function_exists('update_variables_to_config')) {
     update_variables_to_config('ldap_servers.settings', array(
       'ldap_servers_encryption' => 'encryption',


### PR DESCRIPTION
I have been seeing messages like following every time when running Drush command updatedb since 2+ months ago:

> Executing ldap_servers_update_8000
> Performing ldap_servers_update_8000  

It turned that update # 8000 "is reserved for the earliest installation of a module in Drupal 8, before any updates."

References:

- https://github.com/drupal/drupal/blob/8.1.x/core/modules/system/src/Tests/Update/InvalidUpdateHookTest.php#L45
- https://github.com/drupal/drupal/blob/8.1.x/core/includes/update.inc#L312

There isn't any hook_update_8000() method in Drupal core, except the one to test this broken hook.

This pull request is to fix the issue.